### PR TITLE
Call wdt_reset() before bootloader timeout

### DIFF
--- a/hardware/ariadne/bootloaders/ariadne/main.c
+++ b/hardware/ariadne/bootloaders/ariadne/main.c
@@ -129,9 +129,9 @@ int main(void)
 				resetTick();
 				// Unset tftp flag
 				tftpFlashing = FALSE;
-				wdt_reset();
 			}
 		}
+		wdt_reset();
 		/* Blink the notification led */
 		updateLed();
 	}


### PR DESCRIPTION
Bootloader timeout is 20 seconds. The watchdog timeout added in https://github.com/LoathingKernel/Ariadne-Bootloader/commit/e7c70b78c75c69e800f4986b7be7e3e0d44986cb is 8 seconds. This was causing the user application to never be reached after a reset with no upload, instead it would just reset and restart the bootloader every 8 seconds.

@andrebstv if you have the time maybe you could take a look to make sure this change is correct.
