### PR TITLE
Change timeout to 10 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ USB cable and select the serial port and the appropriate board from the __Tools_
 that you must press the reset button and the indication LED on __pin 13__ or __pin 9__, in case of Arduino
 Ethernet, will start blinking rapidly. This means that the bootloader is running and the Arduino is ready
 to be programmed. If there is a __valid__ program already flashed on the Arduino, you have to reprogram
-the device in the next __5 seconds__. If you don't, the bootloader will initiate the program that is
+the device in the next __10 seconds__. If you don't, the bootloader will initiate the program that is
 already in the Arduino. In case there is no program flashed or the program has been marked as __invalid__,
 the bootloader will never time out and you can reprogram it at any time.
 
@@ -259,12 +259,12 @@ not needed.
 tftp> trace
 tftp> verbose
 ```
-Now to actually upload the binary file all you have to do is __reset__ the board and in the next __5
+Now to actually upload the binary file all you have to do is __reset__ the board and in the next __10
 seconds__ run the following command.
 ```
 tftp> put [sketch].bin
 ```
-The __5 second__ time frame is in case you already have a valid program uploaded on the Arduino. In case
+The __10 second__ time frame is in case you already have a valid program uploaded on the Arduino. In case
 you don't have a program loaded or it has been marked invalid, you don't have any time constraints.
 
 Now you should see your tftp client sending packets and the indication LED on __pin 13__ or __pin 9__
@@ -295,7 +295,7 @@ After a successful upload the bootloader will start the uploaded application ins
 
 In case that for some reason the upload fails, first of all stop your TFTP client from sending any more
 packets. After that you should wait for the upload process on the bootloader to timeout. That takes about
-__5 seconds__ too. For this period you should witness the indication led doing some random blinking.
+__10 seconds__ too. For this period you should witness the indication led doing some random blinking.
 After the timeout and since there is no valid program in the memory, the TFTP server should restart itself
 and wait for a new upload.
 

--- a/hardware/ariadne/bootloaders/ariadne/main.c
+++ b/hardware/ariadne/bootloaders/ariadne/main.c
@@ -59,7 +59,7 @@ int main(void)
 	// 0x04 -> ClkIO/256 -> 16us period, 1024ms max
 	// 0x05 -> ClkIO/1024 -> 64us period, 4096ms max
 	// Set up Timer 1 as timekeeper for LED flashing
-	TCCR1B = _BV(CS12) | _BV(CS10); // Same thing as TCCR1B = 0x05;
+	TCCR1B = _BV(CS12); // Same thing as TCCR1B = 0x04;
 
 	/* Write version information in the EEPROM */
 	if(eeprom_read_byte(EEPROM_MAJVER) != ARIADNE_MAJVER)

--- a/hardware/ariadne/bootloaders/ariadne/util.c
+++ b/hardware/ariadne/bootloaders/ariadne/util.c
@@ -25,7 +25,7 @@ void updateLed(void)
 {
 	uint16_t next_timer_1 = TCNT1;
 
-	if(next_timer_1 & 0x400) LED_PORT ^= _BV(LED); // Led pin high
+	if(next_timer_1 & 0x1000) LED_PORT ^= _BV(LED); // Led pin high
 	else LED_PORT &= ~_BV(LED); // Led pin low
 
 	if(next_timer_1 < last_timer_1) {

--- a/hardware/ariadne/bootloaders/ariadne/util.h
+++ b/hardware/ariadne/bootloaders/ariadne/util.h
@@ -1,7 +1,7 @@
 #ifndef util_h
 #define util_h
 
-#define TIMEOUT 4
+#define TIMEOUT 9
 
 #ifndef LED_START_FLASHES
 	#define LED_START_FLASHES 0


### PR DESCRIPTION
Previously the timeout was 20 seconds which was decided to be longer
than necessary. Documentation previously incorrectly stated it was 5
seconds.

Closes https://github.com/LoathingKernel/Ariadne-Bootloader/issues/8
