### PR TITLE
Standard bobuino pin and Arduino name for ATmega1284P LED

### DIFF
--- a/hardware/ariadne/avr/variants/bobuino/pins_arduino.h
+++ b/hardware/ariadne/avr/variants/bobuino/pins_arduino.h
@@ -51,7 +51,7 @@ static const uint8_t SCK  = 13;
 
 static const uint8_t SDA = 23;
 static const uint8_t SCL = 22;
-static const uint8_t LED = 31;
+static const uint8_t LED_BUILTIN = 13;
 
 static const uint8_t A0 = 14;
 static const uint8_t A1 = 15;

--- a/hardware/ariadne/variants/bobuino/pins_arduino.h
+++ b/hardware/ariadne/variants/bobuino/pins_arduino.h
@@ -51,7 +51,7 @@ static const uint8_t SCK  = 13;
 
 static const uint8_t SDA = 23;
 static const uint8_t SCL = 22;
-static const uint8_t LED = 31;
+static const uint8_t LED_BUILTIN = 13;
 
 static const uint8_t A0 = 14;
 static const uint8_t A1 = 15;


### PR DESCRIPTION
The official Bobuino board has the built in LED on pin 13(http://www.crossroadsfencing.com/BobuinoRev17/ATMega1284_thruhole_sch1bw.png) and the mighty-1284p bobuino variant also has this set to 13(https://github.com/JChristensen/mighty-1284p/blob/v1.6.3/avr/variants/bobuino/pins_arduino.h#L49).

Arduino standard name for the built in LED is `LED_BUILTIN` and this is also the name used in the mighty-1284p bobuino variant.
