### PR TITLE
change never timeOut logic

### DIFF
--- a/hardware/ariadne/bootloaders/ariadne/main.c
+++ b/hardware/ariadne/bootloaders/ariadne/main.c
@@ -123,22 +123,24 @@ int main(void)
 
         if(timedOut()) {
 			if(eeprom_read_byte(EEPROM_IMG_STAT) == EEPROM_IMG_OK_VALUE) break;
-
-			//TODO: determine the conditions for reseting server OR reseting socket
-			if(tftpFlashing == TRUE) {
-				// Delete first page of flash memory
-				boot_page_erase(0);
-				// Reinitialize TFTP
-				tftpInit();
-				// Reset the timeout counter
-				resetTick();
-				// Unset tftp flag
-				tftpFlashing = FALSE;
-			}
 		}
-		wdt_reset();
-		/* Blink the notification led */
-		wdt_reset(); //Required so it doesn`t hang.
+
+		//TODO: determine the conditions for reseting server OR reseting socket
+		if(socketResetRequried()) {
+			// Delete first page of flash memory
+			boot_page_erase(0);
+			// Reinitialize TFTP
+			tftpInit();
+			// Reset the timeout counter
+			resetTick();
+			// Unset tftp flag
+			tftpFlashing = FALSE;
+		}
+		
+		//Required so it doesn`t hang.
+		wdt_reset(); 
+		
+		// Blink the notification led 
 		updateLed();
 	}
 

--- a/hardware/ariadne/bootloaders/ariadne/tftp.c
+++ b/hardware/ariadne/bootloaders/ariadne/tftp.c
@@ -37,7 +37,13 @@ const unsigned char tftp_unknown_error_packet[] PROGMEM = "\0\5" "\0\0" "Error";
 #define TFTP_INVALID_IMAGE_LEN 23
 const unsigned char tftp_invalid_image_packet[] PROGMEM = "\0\5" "\0\0" "Invalid image file";
 
-uint16_t lastPacket = 0, highPacket = 0;
+uint8_t tftpFlashing;
+
+#ifndef TFTP_RANDOM_PORT
+static uint16_t tftpTransferPort;
+#endif
+
+static uint16_t lastPacket = 0, highPacket = 0;
 
 
 static void sockInit(uint16_t port)

--- a/hardware/ariadne/bootloaders/ariadne/tftp.h
+++ b/hardware/ariadne/bootloaders/ariadne/tftp.h
@@ -55,11 +55,7 @@
 /**
  * Tftp status flag, it is set to TRUE if flashing from
  * tftp is currently active */
-uint8_t tftpFlashing;
-
-#ifndef TFTP_RANDOM_PORT
-uint16_t tftpTransferPort;
-#endif
+extern uint8_t tftpFlashing;
 
 void tftpInit(void);
 uint8_t tftpPoll(void);

--- a/hardware/ariadne/bootloaders/ariadne/util.c
+++ b/hardware/ariadne/bootloaders/ariadne/util.c
@@ -13,6 +13,7 @@
 #include <util/delay.h>
 
 #include "util.h"
+#include "tftp.h"
 #include "spi.h"
 #include "debug.h"
 #include "debug_util.h"
@@ -52,12 +53,15 @@ void resetTick(void)
 
 uint8_t timedOut(void)
 {
-	// Never timeout if there is no code in Flash
+	// Don't bypass timeout [logic] when tftp is active.
+	if (tftpFlashing == FALSE) {
+		// Never timeout if there is no code in Flash
 #if (FLASHEND > 0x10000)
-	if(pgm_read_word_far(0x0000) == 0xFFFF) return(0);
+		if(pgm_read_word_far(0x0000) == 0xFFFF) return(0);
 #else
-	if(pgm_read_word_near(0x0000) == 0xFFFF) return(0);
+		if(pgm_read_word_near(0x0000) == 0xFFFF) return(0);
 #endif
+	}
 
 	if(tick > TIMEOUT) return(1);
 	else return(0);

--- a/hardware/ariadne/bootloaders/ariadne/util.h
+++ b/hardware/ariadne/bootloaders/ariadne/util.h
@@ -41,6 +41,9 @@
 
 void updateLed(void);
 void resetTick(void);
+void resetSocket(void);
+
 uint8_t timedOut(void);
+uint8_t socketResetRequried(void);
 
 #endif


### PR DESCRIPTION
if tftp started (write request) and then the connection been broken, before the first byte was sent (data packet) and wrote to the flash, Ariadne-Bootloader was hang in "never" timeout state. 

this is very easy to replicate: send something with firewall on. 