### PR TITLE
Address SPI Communication Problem on ATMega2560

### DIFF
--- a/bootloaders/ariadne/src/spi.c
+++ b/bootloaders/ariadne/src/spi.c
@@ -147,6 +147,7 @@ void spiInit(void)
 	/** Set SD SS pin as output */
 	SD_DDR |= _BV(SD_SS);
 
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
 	#if (LED != SCK)
 	/** Set up pins to flash the onboard led */
 	/** Set led pin to high */
@@ -154,6 +155,7 @@ void spiInit(void)
 	/** Set led pin as output */
 	LED_DDR |= _BV(LED);
 	#endif
+#endif
 
 	/** Set up SPI
 	 ** Set the Double SPI Speed Bit */

--- a/bootloaders/ariadne/src/util.c
+++ b/bootloaders/ariadne/src/util.c
@@ -25,8 +25,10 @@ void updateLed(void)
 {
 	uint16_t next_timer_1 = TCNT1;
 
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
 	if(next_timer_1 & 0x1000) LED_PORT ^= _BV(LED); // Led pin high
 	else LED_PORT &= ~_BV(LED); // Led pin low
+#endif
 
 	if(next_timer_1 < last_timer_1) {
 		tick++;


### PR DESCRIPTION
When using the Arduino Mega platform with the W5500 shield, there is contention between the LED signal and the SCK signal. On the Mega, the LED is mapped to digital pin 13. On the Uno, 13 is the SCK signal, but on the Mega these signals are routed to different headers altogether.

The shield still works in sketches because the SPI signals are also routed to the ISCP header, which is connected to the shield.

The logic in the bootloader is that if the SCK pin and LED pin definitions don't match, the LED pin will be initialized and will blink in the bootloader's main polling loop. On the Mega 2560, the SCK pin definition and LED pin definition _do not match_, meaning this logic was included.

Because of the routing of the signals, LED pin (Digital 13) and SCK are actually shorted together, so blinking the LED is causing contention on the SCK line.

For now, LED blinking is disabled on the ATMega2560. With this change, we can successfully upload binaries to the device over Ethernet.

Fixes #37