### PR TITLE
Fix multiple definition of variable not declared extern in headers

### DIFF
--- a/bootloaders/ariadne/src/serial.c
+++ b/bootloaders/ariadne/src/serial.c
@@ -23,7 +23,7 @@
 	#error "Unknown MCU. Cannot find the proper serial bootloader."
 #endif
 
-
+uint8_t serialFlashing = FALSE;
 
 void serialInit(void)
 {

--- a/bootloaders/ariadne/src/serial.h
+++ b/bootloaders/ariadne/src/serial.h
@@ -151,7 +151,7 @@
 
 /* Serial status flag, it is set to TRUE if flashing from
  * serial is currently active */
-uint8_t serialFlashing;
+extern uint8_t serialFlashing;
 
 /*
  * Function definitions

--- a/bootloaders/ariadne/src/tftp.c
+++ b/bootloaders/ariadne/src/tftp.c
@@ -35,7 +35,10 @@ const unsigned char tftp_unknown_error_packet[] PROGMEM = "\0\5" "\0\0" "Error";
 const unsigned char tftp_invalid_image_packet[] PROGMEM = "\0\5" "\0\0" "Invalid image file";
 
 uint16_t lastPacket = 0, highPacket = 0;
-
+uint8_t tftpFlashing = FALSE;
+#ifndef TFTP_RANDOM_PORT
+uint16_t tftpTransferPort;
+#endif
 
 static void sockInit(uint16_t port)
 {

--- a/bootloaders/ariadne/src/tftp.h
+++ b/bootloaders/ariadne/src/tftp.h
@@ -55,10 +55,10 @@
 /**
  * Tftp status flag, it is set to TRUE if flashing from
  * tftp is currently active */
-uint8_t tftpFlashing;
+extern uint8_t tftpFlashing;
 
 #ifndef TFTP_RANDOM_PORT
-uint16_t tftpTransferPort;
+extern uint16_t tftpTransferPort;
 #endif
 
 void tftpInit(void);


### PR DESCRIPTION
Hi 

Thanks for this bootloader. Found a small compilation issue.

System used: 
Manjaro Linux 20.2.1
avr-gcc 10.2.0

Here is the patch I applied.
